### PR TITLE
V0.5.2.rc1

### DIFF
--- a/.cookiecutterrc
+++ b/.cookiecutterrc
@@ -54,7 +54,7 @@ default_context:
     sphinx_doctest: "no"
     sphinx_theme: "sphinx-rtd-theme"
     test_matrix_separate_coverage: "no"
-    version: "0.5.1"
+    version: "0.5.2"
     version_manager: "bump2version"
     website: "https://www.idmod.org"
     year_from: "2023"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ![implementation](https://img.shields.io/pypi/implementation/laser-core.svg)
 ![license](https://img.shields.io/pypi/l/laser-core.svg)
 
-![commits since v0.5.1](https://img.shields.io/github/commits-since/InstituteforDiseaseModeling/laser/v0.5.1.svg)
+![commits since v0.5.2](https://img.shields.io/github/commits-since/InstituteforDiseaseModeling/laser/v0.5.2.svg)
 
 ## Getting Started
 

--- a/README.rst
+++ b/README.rst
@@ -43,9 +43,9 @@ Overview
     :alt: Supported implementations
     :target: https://pypi.org/project/laser-core/
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/InstituteforDiseaseModeling/laser/v0.5.1.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/InstituteforDiseaseModeling/laser/v0.5.2.svg
     :alt: Commits since latest release
-    :target: https://github.com/InstituteforDiseaseModeling/laser/compare/v0.5.1...main
+    :target: https://github.com/InstituteforDiseaseModeling/laser/compare/v0.5.2...main
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ project = "LASER"
 year = "2023-2024"
 author = "Institute for Disease Modeling"
 copyright = f"{year}, {author}"
-version = release = "0.5.1"
+version = release = "0.5.2"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "laser-core"
-version = "0.5.1"
+version = "0.5.2"
 authors = [
   { name="Christopher Lorton", email="christopher.lorton@gatesfoundation.org" },
   { name="Jonathan Bloedow", email="jonathan.bloedow@gatesfoundation.org" },
@@ -131,7 +131,7 @@ ext-modules = [
 "tests" = ["data/*.csv"]
 
 [tool.bumpversion]
-current_version = "0.5.1"
+current_version = "0.5.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 description = "Core functionality for the Light Agent Spatial modeling for ERadication toolkit (LASER)."
 readme = "README.rst"
 license = {file = "LICENSE"}
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 keywords = ["spatial modeling", "disease eradication", "agent-based modeling"]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    # "Programming Language :: Python :: 3.13",   # Not until Numba supports it
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [

--- a/src/laser_core/__init__.py
+++ b/src/laser_core/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 from .extension import compiled
 from .laserframe import LaserFrame

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
     clean,
     check,
     docs,
-    {py39,py310,py311,py312},
+    {py39,py310,py311,py312,py313},
     report
 ignore_basepython_conflict = true
 
@@ -24,6 +24,7 @@ basepython =
     py310: {env:TOXPYTHON:python3.10}
     py311: {env:TOXPYTHON:python3.11}
     py312: {env:TOXPYTHON:python3.12}
+    py313: {env:TOXPYTHON:python3.13}
     {bootstrap,clean,check,report,docs,codecov}: {env:TOXPYTHON:python3.12}
 setenv =
     PYTHONPATH={toxinidir}/tests


### PR DESCRIPTION
This pull request updates the project version from `0.5.1` to `0.5.2` and introduces support for Python 3.13. The changes span multiple configuration files, documentation, and source code to ensure consistency across the project.

### Version Update:

* [`.cookiecutterrc`](diffhunk://#diff-5486ae9a75d4106f4fc965873808eb686c5ecc1324dfe13962cdce2d935e5d98L57-R57): Updated `version` field from `0.5.1` to `0.5.2`.
* [`docs/conf.py`](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L21-R21): Updated `version` and `release` variables to `0.5.2`.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Changed `version` to `0.5.2` and updated `current_version` in the `tool.bumpversion` section. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L134-R134)
* [`src/laser_core/__init__.py`](diffhunk://#diff-ac590a41c38410d21d25886b7f74c6d8f79105fa82a22abf79269207edb23aa6L1-R1): Updated `__version__` to `0.5.2`.

### Python 3.13 Support:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L17-R17): Extended `requires-python` range to `<3.14` and added Python 3.13 to the classifiers. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L17-R17) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L28-R28)
* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L17-R17): Added Python 3.13 (`py313`) to the `envlist` and defined its `basepython`. [[1]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L17-R17) [[2]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R27)

### Documentation Updates:

* `README.md` and `README.rst`: Updated version references in badges and links to reflect `0.5.2`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R17) [[2]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL46-R48)